### PR TITLE
Allow both typed and untyped constants

### DIFF
--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -234,42 +234,53 @@ module.exports = {
       this.next();
     }
 
-    const [nullable, type] =
-      this.version >= 803 ? this.read_optional_type() : [false, null];
+    /*
+     * Reads a constant declaration
+     *
+     * ```ebnf
+     *  constant_declaration ::= (T_STRING | IDENTIFIER) '=' expr
+     * ```
+     * @return {Constant} [:link:](AST.md#constant)
+     */
+    function read_constant_declaration() {
+      const result = this.node("constant");
+      let constName = null;
+      let value = null;
+      if (
+        this.token === this.tok.T_STRING ||
+        (this.version >= 700 && this.is("IDENTIFIER"))
+      ) {
+        constName = this.node("identifier");
+        const name = this.text();
+        this.next();
+        constName = constName(name);
+      } else {
+        this.expect("IDENTIFIER");
+      }
+      if (this.expect("=")) {
+        value = this.next().read_expr();
+      }
+      return result(constName, value);
+    }
+
+    const backup = [this.token, this.lexer.getState()];
+    // Try without a typed constant first
+    let nullable = false, type=null, items;
+    try {
+      items = this.read_list(read_constant_declaration, ",");
+    } catch (e) {
+      if (this.version < 803) {
+        throw e;
+      }
+
+      // rollback state and try with an optional typed constant
+      this.lexer.tokens.push(backup);
+      this.next();
+      [nullable, type] = this.read_optional_type();
+      items = this.read_list(read_constant_declaration, ",");
+    }
 
     const result = this.node("classconstant");
-    const items = this.read_list(
-      /*
-       * Reads a constant declaration
-       *
-       * ```ebnf
-       *  constant_declaration ::= (T_STRING | IDENTIFIER) '=' expr
-       * ```
-       * @return {Constant} [:link:](AST.md#constant)
-       */
-      function read_constant_declaration() {
-        const result = this.node("constant");
-        let constName = null;
-        let value = null;
-        if (
-          this.token === this.tok.T_STRING ||
-          (this.version >= 700 && this.is("IDENTIFIER"))
-        ) {
-          constName = this.node("identifier");
-          const name = this.text();
-          this.next();
-          constName = constName(name);
-        } else {
-          this.expect("IDENTIFIER");
-        }
-        if (this.expect("=")) {
-          value = this.next().read_expr();
-        }
-        return result(constName, value);
-      },
-      ","
-    );
-
     return result(null, items, flags, nullable, type, attrs || []);
   },
   /*

--- a/src/parser/class.js
+++ b/src/parser/class.js
@@ -235,7 +235,7 @@ module.exports = {
     }
 
     const [nullable, type] =
-      this.version >= 830 ? this.read_optional_type() : [false, null];
+      this.version >= 803 ? this.read_optional_type() : [false, null];
 
     const result = this.node("classconstant");
     const items = this.read_list(

--- a/test/snapshot/classconstant.test.js
+++ b/test/snapshot/classconstant.test.js
@@ -41,7 +41,7 @@ describe("classconstant", () => {
     expect(
       parser.parseEval(
         'class Foo { public const string CONSTANT = "Hello world!"; }',
-        { parser: { version: 830 } }
+        { parser: { version: 803 } }
       )
     ).toMatchSnapshot();
   });
@@ -49,7 +49,7 @@ describe("classconstant", () => {
     expect(() =>
       parser.parseEval(
         'class Foo { public const string CONSTANT = "Hello world!"; }',
-        { parser: { version: 820 } }
+        { parser: { version: 802 } }
       )
     ).toThrowErrorMatchingSnapshot();
   });


### PR DESCRIPTION
Using these changes allowed, but also required, typing class constants.  This allows for mixing typed and untyped constants.

Turns the following:
```
<?php
const OUTSIDE_CLASS_CONSTANT     = 5;
class PrettyPrint
{
    private const   float    BLAH = 10_000.500;

    protected const Foo|Stringable|null  D   = null;

    const ?string  NULLABLE_STRING1 = "8.3";

    public const ?string  NULLABLE_STRING2 = "8.3";
    public const    UNTYPED_STRING = "8.3-Special";

}
```

Into this:
```
<?php
const OUTSIDE_CLASS_CONSTANT = 5;
class PrettyPrint
{
    private const float BLAH = 10_000.5;

    protected const Foo|Stringable|null D = null;

    const ?string NULLABLE_STRING1 = '8.3';

    public const ?string NULLABLE_STRING2 = '8.3';
    public const UNTYPED_STRING = '8.3-Special';
}
```